### PR TITLE
Add Compass as an option + more informations to build a specific Sass file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ the load paths and file requires are done for you.
 npm install -g fonzie
 ```
 
-You'll also need to have the Sass gem installed.
+You'll also need to have the Sass gem installed. Optionally Compass if you want to use it.
 
 ## Demo
 
@@ -52,7 +52,7 @@ Then import just what you need in your project:
 }
 ```
 
-Then build your Sass:
+Then build your `main` Sass file:
 
 ```
 fonzie build
@@ -89,6 +89,8 @@ Usage: fonzie <command> [options]
     publish                 Add package to the public registry
 
 ```
+
+Be sure to also try `fonzie <command> --help` for more help about a specific command.
 
 ## Getting Started
 
@@ -151,6 +153,18 @@ This will build the file output it into `build/build.css`. You can change this u
 fonzie build -o public/screen.css
 ```
 
+You can also build a specific Sass file just pass it as the first argument of the build command like this
+
+```
+fonzie build main.scss
+```
+
+And combine source and destination
+
+```
+fonzie build main.scss -o public/main.css
+```
+
 Now you can search for new packages too:
 
 ```
@@ -189,6 +203,16 @@ add a `ruby` section to your `component.json` and add an array of files you want
   "name": "component-name",
   "ruby": ["lib/something.rb"]
 }
+```
+
+## Using Compass
+
+If you don't know it yet, Sass have a `--compass` option.
+
+You can path it to `fonzie build`
+
+```
+fonzie build --compass
 ```
 
 ## Local Packages

--- a/bin/fonzie-build
+++ b/bin/fonzie-build
@@ -18,6 +18,7 @@ program
   .option('-o, --out <dir>', 'output directory defaulting to ./build/build.css', 'build/build.css')
   .option('-s, --style <type>', 'Output style. Can be nested (default), compact, compressed, or expanded.')
   .option('-l, --line-numbers', 'Emit comments in the generated CSS indicating the corresponding source line.')
+  .option('-c, --compass', 'Make Compass imports available and load project configuration.')
   .option('-v, --verbose', 'output verbose build information')
 
 // examples
@@ -30,6 +31,9 @@ program.on('--help', function(){
   console.log();
   console.log('    # build to ./dist as screen.css');
   console.log('    $ fonzie build -o dist/screen.css');
+  console.log();
+  console.log('    # build file.scss to ./dist');
+  console.log('    $ fonzie build file.scss -o dist/file.css');
   console.log();
 });
 
@@ -69,6 +73,10 @@ builder.on('end', function(args){
 
   if(program['line-numbers']) {
     args.push(['--line-numbers']);
+  }
+  
+  if(program['compass']) {
+    args.push(['--compass']);
   }
 
   args.unshift(['sass']);


### PR DESCRIPTION
To get some interesting stuff from Compass, it's great to path this option to Sass command.
& I just add an another example about a simple fonzie usage.
